### PR TITLE
fix: address HIGH and MEDIUM security audit findings

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -144,11 +144,14 @@ fn fetch_full(url: &str, max_bytes: Option<usize>) -> Result<FetchResult, HttpEr
         buf
     } else {
         let mut buf = Vec::new();
-        reader.take(MAX_BYTES).read_to_end(&mut buf)?;
+        (&mut reader).take(MAX_BYTES).read_to_end(&mut buf)?;
         if buf.len() as u64 == MAX_BYTES {
-            eprintln!(
-                "warning: HTTP response exceeds 1 GB; sniffing on truncated sample — results may be inaccurate"
-            );
+            let mut probe = [0u8; 1];
+            if reader.read(&mut probe)? > 0 {
+                eprintln!(
+                    "warning: HTTP response exceeds 1 GB; sniffing on truncated sample — results may be inaccurate"
+                );
+            }
         }
         buf
     };

--- a/src/http.rs
+++ b/src/http.rs
@@ -145,6 +145,11 @@ fn fetch_full(url: &str, max_bytes: Option<usize>) -> Result<FetchResult, HttpEr
     } else {
         let mut buf = Vec::new();
         reader.take(MAX_BYTES).read_to_end(&mut buf)?;
+        if buf.len() as u64 == MAX_BYTES {
+            eprintln!(
+                "warning: HTTP response exceeds 1 GB; sniffing on truncated sample — results may be inaccurate"
+            );
+        }
         buf
     };
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -137,13 +137,14 @@ fn fetch_full(url: &str, max_bytes: Option<usize>) -> Result<FetchResult, HttpEr
     let body = response.into_body();
     let mut reader = body.into_reader();
 
+    const MAX_BYTES: u64 = 1024 * 1024 * 1024; // 1 GB hard cap
     let data = if let Some(bytes) = max_bytes {
         let mut buf = Vec::with_capacity(bytes);
         reader.take(bytes as u64).read_to_end(&mut buf)?;
         buf
     } else {
         let mut buf = Vec::new();
-        reader.read_to_end(&mut buf)?;
+        reader.take(MAX_BYTES).read_to_end(&mut buf)?;
         buf
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,7 +379,8 @@ fn print_json_output(path: &str, metadata: &csv_nose::Metadata, verbose: bool) {
 }
 
 fn print_csv_output(path: &str, metadata: &csv_nose::Metadata) {
-    static mut HEADER_PRINTED: bool = false;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static HEADER_PRINTED: AtomicBool = AtomicBool::new(false);
 
     let quote_str = match metadata.dialect.quote {
         Quote::None => "none".to_string(),
@@ -387,13 +388,10 @@ fn print_csv_output(path: &str, metadata: &csv_nose::Metadata) {
     };
 
     // CSV header (print only for first file or could be configured)
-    unsafe {
-        if !HEADER_PRINTED {
-            println!(
-                "file,delimiter,quote,has_header,preamble_rows,flexible,is_utf8,num_fields,avg_record_len"
-            );
-            HEADER_PRINTED = true;
-        }
+    if !HEADER_PRINTED.swap(true, Ordering::SeqCst) {
+        println!(
+            "file,delimiter,quote,has_header,preamble_rows,flexible,is_utf8,num_fields,avg_record_len"
+        );
     }
 
     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,7 +388,7 @@ fn print_csv_output(path: &str, metadata: &csv_nose::Metadata) {
     };
 
     // CSV header (print only for first file or could be configured)
-    if !HEADER_PRINTED.swap(true, Ordering::SeqCst) {
+    if !HEADER_PRINTED.swap(true, Ordering::Relaxed) {
         println!(
             "file,delimiter,quote,has_header,preamble_rows,flexible,is_utf8,num_fields,avg_record_len"
         );

--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -191,6 +191,11 @@ impl Sniffer {
                 const MAX_BYTES: u64 = 1024 * 1024 * 1024; // 1 GB hard cap
                 let mut buffer = Vec::new();
                 reader.take(MAX_BYTES).read_to_end(&mut buffer)?;
+                if buffer.len() as u64 == MAX_BYTES {
+                    eprintln!(
+                        "warning: input exceeds 1 GB; sniffing on truncated sample — results may be inaccurate"
+                    );
+                }
                 Ok(buffer)
             }
             SampleSize::Records(n) => {

--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -757,7 +757,7 @@ mod tests {
         );
         let cursor = std::io::Cursor::new(data);
         let mut sniffer = Sniffer::new();
-        // Records(200_000): estimated_size = 200_000 * 1024 ≈ 200 MB, clamped to MAX_RECORDS_BYTES.
+        // Records(200_000): estimated_size = 200_000 * 1024 > MAX_RECORDS_BYTES (100 MB), clamped to MAX_RECORDS_BYTES.
         sniffer.sample_size(SampleSize::Records(200_000));
         let result = sniffer.sniff_reader(cursor);
         assert!(

--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -190,11 +190,14 @@ impl Sniffer {
             SampleSize::All => {
                 const MAX_BYTES: u64 = 1024 * 1024 * 1024; // 1 GB hard cap
                 let mut buffer = Vec::new();
-                reader.take(MAX_BYTES).read_to_end(&mut buffer)?;
+                (&mut reader).take(MAX_BYTES).read_to_end(&mut buffer)?;
                 if buffer.len() as u64 == MAX_BYTES {
-                    eprintln!(
-                        "warning: input exceeds 1 GB; sniffing on truncated sample — results may be inaccurate"
-                    );
+                    let mut probe = [0u8; 1];
+                    if reader.read(&mut probe)? > 0 {
+                        eprintln!(
+                            "warning: input exceeds 1 GB; sniffing on truncated sample — results may be inaccurate"
+                        );
+                    }
                 }
                 Ok(buffer)
             }


### PR DESCRIPTION
- Replace `static mut HEADER_PRINTED` with `AtomicBool` to eliminate the data race in `print_csv_output` (HIGH)
- Use `saturating_mul` instead of bare `*` for record-based buffer size calculations in `sniffer.rs` to prevent integer overflow (HIGH x2)
- Cap `SampleSize::All` reads at 1 GB in `sniffer.rs` to prevent unbounded memory allocation (MEDIUM)
- Cap unbounded HTTP reads at 1 GB in `http.rs` when no `max_bytes` limit is set (MEDIUM)