### PR TITLE
Fix dialect/table mismatch and tolerate short reads

### DIFF
--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -160,9 +160,20 @@ impl Sniffer {
         let best = find_best_dialect(&scores)
             .ok_or_else(|| SnifferError::NoDialectDetected("No valid dialect found".to_string()))?;
 
-        // Detect structural preamble using the already-parsed table
-        let table_for_preamble =
-            best_table.unwrap_or_else(|| parse_table(data, &best.dialect, max_rows));
+        // Detect structural preamble using the already-parsed table.
+        //
+        // `best_table` was parsed with the top-gamma dialect (scores[0]), but
+        // `find_best_dialect` may deliberately select a different dialect when
+        // scores are close (delimiter/quote tiebreakers). Reuse the cached table
+        // only when the selected dialect IS the top-gamma one; otherwise re-parse
+        // with the selected dialect so preamble detection, field names, and type
+        // inference all run on the correct parse.
+        let best_is_top_gamma = scores.first().is_some_and(|top| top.dialect == best.dialect);
+        let table_for_preamble = if best_is_top_gamma {
+            best_table.unwrap_or_else(|| parse_table(data, &best.dialect, max_rows))
+        } else {
+            parse_table(data, &best.dialect, max_rows)
+        };
         let structural_preamble = detect_structural_preamble(&table_for_preamble);
 
         // Total preamble = comment rows + structural rows
@@ -183,10 +194,27 @@ impl Sniffer {
 
     /// Read a sample of data from the reader based on `sample_size` settings.
     fn read_sample<R: Read + Seek>(&self, mut reader: R) -> Result<Vec<u8>> {
+        // `Read::read` may return fewer bytes than requested even when more data
+        // is available (pipes, BufReader chunk boundaries). Loop until the buffer
+        // is full or EOF is reached so the sample is not silently truncated.
+        // Returns the number of bytes actually read.
+        fn fill<R: Read>(reader: &mut R, buf: &mut [u8]) -> std::io::Result<usize> {
+            let mut filled = 0;
+            while filled < buf.len() {
+                match reader.read(&mut buf[filled..]) {
+                    Ok(0) => break,
+                    Ok(n) => filled += n,
+                    Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                    Err(e) => return Err(e),
+                }
+            }
+            Ok(filled)
+        }
+
         match self.sample_size {
             SampleSize::Bytes(n) => {
                 let mut buffer = vec![0u8; n];
-                let bytes_read = reader.read(&mut buffer)?;
+                let bytes_read = fill(&mut reader, &mut buffer)?;
                 buffer.truncate(bytes_read);
                 Ok(buffer)
             }
@@ -209,10 +237,10 @@ impl Sniffer {
                 // Estimate ~1KB per record as a starting point, with a minimum
                 let estimated_size = n.saturating_mul(1024).clamp(8192, MAX_RECORDS_BYTES);
                 let mut buffer = vec![0u8; estimated_size];
-                let bytes_read = reader.read(&mut buffer)?;
+                let bytes_read = fill(&mut reader, &mut buffer)?;
                 buffer.truncate(bytes_read);
 
-                // If we need more data, keep reading
+                // If we filled the estimate, we may not have enough records yet.
                 if bytes_read == estimated_size {
                     // Count newlines to see if we have enough records
                     let newlines = bytecount::count(&buffer, b'\n');
@@ -220,7 +248,7 @@ impl Sniffer {
                         // Read more data
                         let additional = (n - newlines).saturating_mul(2048).min(MAX_RECORDS_BYTES);
                         let mut more = vec![0u8; additional];
-                        let more_read = reader.read(&mut more)?;
+                        let more_read = fill(&mut reader, &mut more)?;
                         more.truncate(more_read);
                         buffer.extend(more);
                     }
@@ -276,7 +304,7 @@ impl Sniffer {
             };
 
         // Detect header on the effective table (pass total_preamble_rows for Header metadata)
-        let header = detect_header(&effective_table, &score.dialect, total_preamble_rows);
+        let header = detect_header(&effective_table, total_preamble_rows);
 
         // Get field names from the effective table (first row after structural preamble)
         let fields = if header.has_header_row && !effective_table.rows.is_empty() {
@@ -327,11 +355,7 @@ impl Sniffer {
 /// Detect if the first row (after preamble) is likely a header row.
 ///
 /// Optimized: Computes type counts in a single pass without allocating Vecs.
-fn detect_header(
-    table: &crate::tum::table::Table,
-    _dialect: &PotentialDialect,
-    preamble_rows: usize,
-) -> Header {
+fn detect_header(table: &crate::tum::table::Table, preamble_rows: usize) -> Header {
     if table.rows.is_empty() {
         return Header::new(false, preamble_rows);
     }

--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -162,17 +162,15 @@ impl Sniffer {
 
         // Detect structural preamble using the already-parsed table.
         //
-        // `best_table` was parsed with the top-gamma dialect (scores[0]), but
+        // `best_table` was parsed with the top-gamma dialect, but
         // `find_best_dialect` may deliberately select a different dialect when
         // scores are close (delimiter/quote tiebreakers). Reuse the cached table
-        // only when the selected dialect IS the top-gamma one; otherwise re-parse
-        // with the selected dialect so preamble detection, field names, and type
-        // inference all run on the correct parse.
-        let best_is_top_gamma = scores.first().is_some_and(|top| top.dialect == best.dialect);
-        let table_for_preamble = if best_is_top_gamma {
-            best_table.unwrap_or_else(|| parse_table(data, &best.dialect, max_rows))
-        } else {
-            parse_table(data, &best.dialect, max_rows)
+        // only when it was parsed with the dialect we actually selected;
+        // otherwise re-parse with the selected dialect so preamble detection,
+        // field names, and type inference all run on the correct parse.
+        let table_for_preamble = match best_table {
+            Some((dialect, table)) if dialect == best.dialect => table,
+            _ => parse_table(data, &best.dialect, max_rows),
         };
         let structural_preamble = detect_structural_preamble(&table_for_preamble);
 
@@ -245,8 +243,11 @@ impl Sniffer {
                     // Count newlines to see if we have enough records
                     let newlines = bytecount::count(&buffer, b'\n');
                     if newlines < n {
-                        // Read more data
-                        let additional = (n - newlines).saturating_mul(2048).min(MAX_RECORDS_BYTES);
+                        // Read more data, but never let the total exceed the
+                        // MAX_RECORDS_BYTES cap (cap against remaining capacity,
+                        // not just per-read).
+                        let remaining = MAX_RECORDS_BYTES.saturating_sub(buffer.len());
+                        let additional = (n - newlines).saturating_mul(2048).min(remaining);
                         let mut more = vec![0u8; additional];
                         let more_read = fill(&mut reader, &mut more)?;
                         more.truncate(more_read);

--- a/src/tum/score.rs
+++ b/src/tum/score.rs
@@ -1026,7 +1026,12 @@ pub fn score_all_dialects(
 }
 
 /// Score all potential dialects and return sorted by gamma score (descending),
-/// along with the parsed table of the best-scoring dialect.
+/// along with the parsed table of the best-scoring dialect and the dialect it
+/// was parsed with.
+///
+/// Returning the dialect lets callers verify that the cached table matches the
+/// dialect they ultimately select (which may differ from the top-gamma one due
+/// to tiebreakers) without relying on `scores` ordering.
 ///
 /// This avoids re-parsing the best dialect's data for preamble detection
 /// and metadata building.
@@ -1034,7 +1039,7 @@ pub fn score_all_dialects_with_best_table(
     data: &[u8],
     dialects: &[PotentialDialect],
     max_rows: usize,
-) -> (Vec<DialectScore>, Option<Table>) {
+) -> (Vec<DialectScore>, Option<(PotentialDialect, Table)>) {
     // Pre-compute quote counts once for all dialect evaluations
     let quote_counts = QuoteCounts::new(data);
 
@@ -1089,7 +1094,7 @@ pub fn score_all_dialects_with_best_table(
                 .unwrap_or(std::cmp::Ordering::Equal)
                 .then_with(|| j.cmp(i)) // lower index wins on tie
         })
-        .map(|(_, (_, t))| t.clone());
+        .map(|(_, (s, t))| (s.dialect.clone(), t.clone()));
 
     let mut scores: Vec<DialectScore> = pairs.into_iter().map(|(s, _)| s).collect();
 

--- a/tests/benchmark_accuracy.rs
+++ b/tests/benchmark_accuracy.rs
@@ -29,13 +29,12 @@ fn parse_accuracy_from_output(output: &str) -> Option<f64> {
     for line in output.lines() {
         if line.contains("Passed:") && line.contains('%') {
             // Extract the percentage from the line
-            if let Some(start) = line.find('(') {
-                if let Some(end) = line.find('%') {
-                    if start < end {
-                        let pct_str = &line[start + 1..end];
-                        return pct_str.trim().parse().ok();
-                    }
-                }
+            if let Some(start) = line.find('(')
+                && let Some(end) = line.find('%')
+                && start < end
+            {
+                let pct_str = &line[start + 1..end];
+                return pct_str.trim().parse().ok();
             }
         }
     }


### PR DESCRIPTION
## Summary

Two correctness fixes found during a codebase review, plus two minor cleanups.

### 1. Dialect/table mismatch (output correctness)
`sniff_bytes` cached `best_table` from `score_all_dialects_with_best_table`, which is parsed with the **top-gamma** dialect (`scores[0]`). But `find_best_dialect` deliberately selects a *different* dialect when scores are within 5% (the delimiter/quote tiebreakers). When they diverged, the cached table — parsed with the wrong delimiter — was still used for preamble detection, field names, and type inference, while `num_fields`/dialect came from the selected dialect. This yields metadata derived from an inconsistent parse.

Fix: reuse the cached table only when the selected dialect **is** the top-gamma one; otherwise re-parse with the selected dialect.

### 2. Short reads in `read_sample`
`Read::read` may return fewer bytes than requested even when more data is available (pipes, `BufReader` chunk boundaries). The `Bytes` and `Records` branches assumed a single `read` filled the buffer, so a short read could silently truncate the sample and skew detection. Added a `fill()` helper that loops until the buffer is full or EOF (retrying on `Interrupted`); both branches now use it. (`All` was already correct via `read_to_end`.)

### Minor cleanups
- Collapse nested `if let` blocks in `tests/benchmark_accuracy.rs` using edition-2024 let-chains (clears 2 clippy warnings).
- Remove the unused `_dialect` parameter from `detect_header` and its call site.

## Testing
- `cargo clippy --all-targets` — clean (0 warnings)
- `cargo test` — all pass (62 + 4 + 6 + 26 unit/integration + 3 doctests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)