### PR TITLE
test: cover blank-line handling in skip_preamble

### DIFF
--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -683,6 +683,45 @@ mod tests {
     }
 
     #[test]
+    fn test_skip_preamble_blank_lines_within_comment_block() {
+        // A blank line between comments is part of the comment block.
+        let data = b"#c\n\n#d\ndata\n";
+        let (preamble_rows, remaining) = skip_preamble(data);
+        assert_eq!(preamble_rows, 3);
+        assert_eq!(remaining, b"data\n");
+
+        // Trailing blanks followed by data belong to the data, not the preamble.
+        let data = b"#c\n\n\ndata\n";
+        let (preamble_rows, remaining) = skip_preamble(data);
+        assert_eq!(preamble_rows, 1);
+        assert_eq!(remaining, b"\n\ndata\n");
+
+        // Several blank runs interleaved with comments, then a trailing run.
+        let data = b"#a\n\n#b\n\n\n#c\n\ndata\n";
+        let (preamble_rows, remaining) = skip_preamble(data);
+        assert_eq!(preamble_rows, 6);
+        assert_eq!(remaining, b"\ndata\n");
+
+        // Leading blanks with no comment at all: nothing is preamble.
+        let data = b"\n\nname,age\n";
+        let (preamble_rows, remaining) = skip_preamble(data);
+        assert_eq!(preamble_rows, 0);
+        assert_eq!(remaining, b"\n\nname,age\n");
+
+        // Whitespace-only lines count as blank, and CRLF is handled.
+        let data = b"#c\r\n   \r\n#d\r\ndata\r\n";
+        let (preamble_rows, remaining) = skip_preamble(data);
+        assert_eq!(preamble_rows, 3);
+        assert_eq!(remaining, b"data\r\n");
+
+        // A comment block that runs to EOF with trailing blanks.
+        let data = b"#c\n\n";
+        let (preamble_rows, remaining) = skip_preamble(data);
+        assert_eq!(preamble_rows, 1);
+        assert_eq!(remaining, b"\n");
+    }
+
+    #[test]
     fn test_sniff_with_preamble() {
         let data = b"# LimeSurvey export\n# Generated 2024-01-01\nname,age,city\nAlice,30,NYC\nBob,25,LA\n";
         let sniffer = Sniffer::new();


### PR DESCRIPTION
Restores a commit that was left behind when #38 merged.

#38's merge commit (`412dbd9`) has parents `4613a4f` and `fe44738` — it captured the
branch one commit early, so `b394d0a` never reached `main`. Verified with
`git merge-base --is-ancestor` and by grepping `origin/main:src/sniffer.rs`, which has no
match for the new test.

That commit is the fix for roborev job 4073, which is closed as addressed. Without it,
`main` carries the blank-tolerant `skip_preamble` change with no coverage of the behavior
it added.

Tests only — no behavior change. The existing `test_skip_preamble` cases contain no blank
lines by design (they were used as a tripwire to prove the change stayed backward
compatible), which is exactly why they don't cover this.

| Input | Preamble rows | Remainder |
|:------|:--------------|:----------|
| `#c\n\n#d\ndata` | 3 | `data` |
| `#c\n\n\ndata` | 1 | `\n\ndata` (blanks preserved) |
| `#a\n\n#b\n\n\n#c\n\ndata` | 6 | `\ndata` |
| `\n\nname,age` | 0 | unchanged |
| `#c\r\n   \r\n#d\r\ndata\r\n` | 3 | `data\r\n` |
| `#c\n\n` (EOF) | 1 | `\n` |

The last three are where an off-by-one in the buffering would hide: whitespace-only lines
counting as blank, CRLF, and a comment block running to EOF.

Should merge before the 1.2.0 release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157eHFUMQ8HJz6icqx92hJP