### PR TITLE
chore: ignore benchmark accuracy tests by default

### DIFF
--- a/.claude/agents/benchmark-checker.md
+++ b/.claude/agents/benchmark-checker.md
@@ -10,13 +10,20 @@ Run this agent after changes to scoring, parsing, or detection logic — particu
 
 1. Run the benchmark integration tests:
    ```
-   cargo test --test benchmark_accuracy -- --nocapture
+   cargo test --test benchmark_accuracy -- --include-ignored --nocapture
    ```
-2. Parse accuracy percentages from the output for each dataset (POLLOCK, W3C-CSVW, CSV Wrangling, CODEC, MESSY)
-3. Read the benchmark tables in README.md to get the expected accuracy values
-4. Compare actual vs expected for each metric (delimiter, quotechar, overall accuracy)
-5. Report results as a summary table
-6. Flag any regressions where accuracy drops by more than 0.5%
+   `--include-ignored` is mandatory. These tests are `#[ignore]` by default so a fresh
+   clone gets a clean `cargo test`; without the flag this command exits 0 having run
+   nothing, and there would be no output to parse.
+2. Confirm the run reported `6 passed`. If it reports `6 ignored`, the flag was dropped —
+   rerun with it. If it reports failures mentioning a missing test data directory, the
+   CSVsniffer corpora are not installed (see README "Benchmark Setup"); report that as
+   INCONCLUSIVE rather than a regression.
+3. Parse accuracy percentages from the output for each dataset (POLLOCK, W3C-CSVW, CSV Wrangling, CODEC, MESSY)
+4. Read the benchmark tables in README.md to get the expected accuracy values
+5. Compare actual vs expected for each metric (delimiter, quotechar, overall accuracy)
+6. Report results as a summary table
+7. Flag any regressions where accuracy drops by more than 0.5%
 
 ## Output Format
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,5 +25,9 @@ jobs:
         cp -r /tmp/CSVsniffer/CSV/* tests/data/pollock/
         cp -r /tmp/CSVsniffer/W3C-CSVW/* tests/data/w3c-csvw/
         cp -r "/tmp/CSVsniffer/CSV_Wrangling/data/github/Curated files/"* tests/data/csv-wrangling/
+    # --include-ignored is required: the benchmark accuracy tests are #[ignore]
+    # by default so a fresh clone (which lacks the gitignored CSVsniffer
+    # corpora) gets a clean `cargo test`. CI copies the corpora above, so it
+    # must opt in — without this flag the accuracy gate would silently not run.
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose -- --include-ignored

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,17 @@ cargo run --release -- --benchmark tests/data/csv-wrangling --annotations tests/
 # Run benchmark with custom annotations file
 cargo run --release -- --benchmark tests/data/pollock --annotations tests/data/annotations/pollock.txt
 
-# Run benchmark integration tests with output
-cargo test --test benchmark_accuracy -- --nocapture
+# Run benchmark integration tests with output.
+# --include-ignored is required — see note below.
+cargo test --test benchmark_accuracy -- --include-ignored --nocapture
 ```
 
 Note: Benchmark test files must be copied from [CSVsniffer](https://github.com/ws-garcia/CSVsniffer). See README.md "Benchmark Setup" section.
+
+The benchmark accuracy tests are `#[ignore]` by default so a fresh clone, which lacks the
+gitignored corpora, gets a clean `cargo test` instead of six panics. They still panic (rather
+than skipping) when explicitly run without the data, so an accuracy run can never silently
+pass having tested nothing. CI copies the corpora and runs with `--include-ignored`.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 cargo build              # Build debug
 cargo build --release    # Build optimized release
-cargo test               # Run all tests (unit + integration + doc tests)
+cargo test               # Unit + integration + doc tests (benchmark accuracy tests are ignored; see below)
 cargo test test_name     # Run single test by name
 cargo run -- file.csv    # Run CLI on a file
 cargo clippy             # Lint

--- a/README.md
+++ b/README.md
@@ -258,8 +258,10 @@ cargo run --release -- --benchmark tests/data/csv-wrangling --annotations tests/
 # Run benchmark on CSV Wrangling MESSY (126 non-normal files)
 cargo run --release -- --benchmark tests/data/csv-wrangling --annotations tests/data/annotations/csv-wrangling-messy.txt
 
-# Run integration tests with detailed output
-cargo test --test benchmark_accuracy -- --nocapture
+# Run integration tests with detailed output.
+# --include-ignored is required: these tests are #[ignore] by default so that
+# `cargo test` on a fresh clone (which has no benchmark corpora) stays green.
+cargo test --test benchmark_accuracy -- --include-ignored --nocapture
 ```
 
 ## License

--- a/docs/BENCHMARK_DATASETS_INFO.md
+++ b/docs/BENCHMARK_DATASETS_INFO.md
@@ -84,20 +84,20 @@ The CODEC and MESSY subsets filter this dataset:
 
 ## Implications for Detection
 
-### Why W3C-CSVW has highest accuracy (99.55%)
+### Why W3C-CSVW has high accuracy (99.55%)
 
 - Uniform dialect (comma + double-quote) matches csv-nose's default preferences
 - Well-formed files with clear quoting patterns
 - Boundary detection works well with consistent structure
 
-### Why CSV Wrangling has lower accuracy (~93%)
+### Why CSV Wrangling has lower accuracy (~95%)
 
 - Delimiter diversity: 29% use non-comma delimiters
 - Rare delimiters (§, space) have detection penalties
 - Some annotation errors in expected dialects
 - Real-world files often have ambiguous structures
 
-### Why POLLOCK is in between (97.97%)
+### Why POLLOCK is in between (98.65%)
 
 - Intentionally challenging edge cases
 - Tests specific failure modes
@@ -108,8 +108,10 @@ The CODEC and MESSY subsets filter this dataset:
 See [README.md](README.md#benchmark-setup) for instructions on setting up and running benchmarks.
 
 ```bash
-# Run all benchmarks
-cargo test --test benchmark_accuracy -- --nocapture
+# Run all benchmarks. --include-ignored is required: these tests are #[ignore]
+# by default so that `cargo test` on a fresh clone, which has no corpora,
+# stays green. Without the flag the command succeeds having run nothing.
+cargo test --test benchmark_accuracy -- --include-ignored --nocapture
 
 # Run individual dataset
 cargo run --release -- --benchmark tests/data/pollock

--- a/tests/benchmark_accuracy.rs
+++ b/tests/benchmark_accuracy.rs
@@ -123,6 +123,7 @@ fn run_benchmark_with_annotations(
 }
 
 #[test]
+#[ignore = "requires CSVsniffer corpora; see README 'Benchmark Setup'"]
 fn test_pollock_accuracy() {
     let (total, accuracy, stdout) = run_dataset_benchmark("pollock");
 
@@ -139,6 +140,7 @@ fn test_pollock_accuracy() {
 }
 
 #[test]
+#[ignore = "requires CSVsniffer corpora; see README 'Benchmark Setup'"]
 fn test_w3c_csvw_accuracy() {
     let (total, accuracy, stdout) = run_dataset_benchmark("w3c-csvw");
 
@@ -155,6 +157,7 @@ fn test_w3c_csvw_accuracy() {
 }
 
 #[test]
+#[ignore = "requires CSVsniffer corpora; see README 'Benchmark Setup'"]
 fn test_csv_wrangling_accuracy() {
     let (total, accuracy, stdout) = run_dataset_benchmark("csv-wrangling");
 
@@ -167,6 +170,7 @@ fn test_csv_wrangling_accuracy() {
 }
 
 #[test]
+#[ignore = "requires CSVsniffer corpora; see README 'Benchmark Setup'"]
 fn test_csv_wrangling_codec_accuracy() {
     // Uses csv-wrangling data dir but csv-wrangling-codec annotations
     let (total, accuracy, stdout) =
@@ -181,6 +185,7 @@ fn test_csv_wrangling_codec_accuracy() {
 }
 
 #[test]
+#[ignore = "requires CSVsniffer corpora; see README 'Benchmark Setup'"]
 fn test_csv_wrangling_messy_accuracy() {
     // Uses csv-wrangling data dir but csv-wrangling-messy annotations (only non-normal files)
     let (total, accuracy, stdout) =
@@ -195,6 +200,7 @@ fn test_csv_wrangling_messy_accuracy() {
 }
 
 #[test]
+#[ignore = "requires CSVsniffer corpora; see README 'Benchmark Setup'"]
 fn test_combined_accuracy_report() {
     let (pollock_total, pollock_accuracy, _) = run_dataset_benchmark("pollock");
     let (w3c_total, w3c_accuracy, _) = run_dataset_benchmark("w3c-csvw");


### PR DESCRIPTION
Closes the last loose end from the v1.2.0 work: `tests/data/` is gitignored, so a **fresh
clone greets a new contributor with six panics** from `cargo test`. The suite is unusable as
a "did I break anything" check until they've set up several hundred MB of third-party
corpora — even for a typo fix.

## The approach, and the one I rejected

The tempting fix is a runtime skip — `if !csv_dir.exists() { eprintln!(...); return; }`.

**I deliberately didn't do that.** A skipping test reports **`ok`** — a passing test that
tested nothing, on this project's *accuracy gate*. If the CI corpora copy ever drifts
(upstream repo layout change, a `cp` that matches nothing), you'd get a green build with
zero benchmark coverage and no signal at all. `ignored` is honest about not having run;
`ok` is not.

`#[ignore]` separates the two situations that deserve different answers:

| Situation | Behavior |
|:--|:--|
| No corpora, benchmarks not asked for | `ignored`, green |
| Corpora missing, benchmarks explicitly asked for | **panics, red** (unchanged) |

The reason string is printed inline by libtest, so the output explains itself exactly when
someone is confused:

```
test test_pollock_accuracy ... ignored, requires CSVsniffer corpora; see README 'Benchmark Setup'
```

## Changes

- `tests/benchmark_accuracy.rs` — `#[ignore = "..."]` on all six tests
- `.github/workflows/rust.yml` — `cargo test --verbose -- --include-ignored`, with a comment
  explaining that omitting the flag would silently disable the accuracy gate
- `README.md`, `CLAUDE.md` — documented benchmark commands updated to match

## Verification

All four combinations were exercised, including temporarily moving `tests/data` aside:

| Corpora | Command | Result |
|:--|:--|:--|
| present | `cargo test` | 6 ignored, green |
| present | `-- --include-ignored` | **6 pass** (really runs) |
| **absent** | `-- --include-ignored` | **6 FAIL loudly** ← the false-green guard |
| absent | `cargo test` | 6 ignored, green |

Row 3 is the one that matters: CI cannot silently skip. Full suite unchanged otherwise
(87 + 4 + 26 + 3 pass), `cargo fmt --check` clean.

## Tradeoff

Anyone who *does* have the corpora must now pass `--include-ignored`, or their benchmark run
silently does nothing. That's a real papercut. Mitigated by the reason string being visible
in output and all three documented commands being updated — but worth knowing.

Independent of the v1.2.0 release; safe to land whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157eHFUMQ8HJz6icqx92hJP