### PR TITLE
fix: detect is_utf8 before transcoding, not after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Dialect.is_utf8` now reports whether the input was actually valid UTF-8. It was computed from the *transcoded* sample: `detect_and_transcode` runs first, and `encoding_rs::decode` always emits valid UTF-8 — substituting replacement characters for malformed input — so the check that followed saw valid UTF-8 no matter what was fed in. Every file, in every encoding, was reported as `is_utf8: true`, including through the CLI's plain, JSON and CSV output. Detection now runs on the original bytes, before transcoding
+
 ## [1.2.0] - 2026-08-06
 
 ### Added

--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -113,13 +113,18 @@ impl Sniffer {
             return Err(SnifferError::EmptyData);
         }
 
-        // Detect encoding and transcode to UTF-8 if necessary
-        let (transcoded_data, was_transcoded) = detect_and_transcode(data);
-        let data = &transcoded_data[..];
+        // Detect encoding info from the *original* bytes, before transcoding.
+        // `encoding_rs::decode` always emits valid UTF-8, substituting
+        // replacement characters for malformed input, so inspecting the
+        // transcoded bytes reports `is_utf8: true` for every input.
+        let is_utf8 = detect_encoding(data).is_utf8;
 
-        // Detect encoding info (for metadata)
-        let encoding_info = detect_encoding(data);
-        let is_utf8 = !was_transcoded || encoding_info.is_utf8;
+        // Detect encoding and transcode to UTF-8 if necessary. The second
+        // return value (whether a transcode happened) has no remaining reader;
+        // leave it in place pending the encoding-metadata work in #44, which
+        // reworks this signature to surface the detected encoding itself.
+        let (transcoded_data, _) = detect_and_transcode(data);
+        let data = &transcoded_data[..];
 
         // Skip BOM
         let data = skip_bom(data);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -201,6 +201,34 @@ fn test_utf8_bom() {
 }
 
 #[test]
+fn test_non_utf8_is_not_reported_as_utf8() {
+    // Windows-1252 "José,São Paulo" — 0xE9/0xE3/0xFC are not valid UTF-8.
+    let data = b"name,city\nJos\xE9,S\xE3o Paulo\nRen\xE9e,Z\xFCrich\n";
+
+    let sniffer = Sniffer::new();
+    let metadata = sniffer.sniff_bytes(data).unwrap();
+
+    // The sample is transcoded before parsing, so the dialect is still found,
+    assert_eq!(metadata.dialect.delimiter, b',');
+    // but the file itself was not valid UTF-8.
+    assert!(!metadata.dialect.is_utf8);
+}
+
+#[test]
+fn test_utf16le_bom_is_not_reported_as_utf8() {
+    let mut data = vec![0xFF, 0xFE]; // UTF-16LE BOM
+    for unit in "a,b\n1,2\n3,4\n".encode_utf16() {
+        data.extend_from_slice(&unit.to_le_bytes());
+    }
+
+    let sniffer = Sniffer::new();
+    let metadata = sniffer.sniff_bytes(&data).unwrap();
+
+    assert_eq!(metadata.dialect.delimiter, b',');
+    assert!(!metadata.dialect.is_utf8);
+}
+
+#[test]
 fn test_empty_file_error() {
     let data = b"";
     let sniffer = Sniffer::new();


### PR DESCRIPTION
Found while triaging #44.

## The bug

`Dialect.is_utf8` was unconditionally `true`:

```rust
let (transcoded_data, was_transcoded) = detect_and_transcode(data);
let data = &transcoded_data[..];
let encoding_info = detect_encoding(data);          // <- post-transcode
let is_utf8 = !was_transcoded || encoding_info.is_utf8;
```

- `was_transcoded == false` → `!false` short-circuits to `true`
- `was_transcoded == true` → `encoding_info` was computed on the *decoded* bytes, and `encoding_rs::decode` always emits valid UTF-8 (replacement characters for malformed input) → `true` again

So every file, in every encoding, reported `is_utf8: true` — through the library and through the CLI's plain, JSON and CSV output.

## The fix

Run `detect_encoding` on the original bytes, before transcoding.

| input | before | after | delimiter |
| --- | --- | --- | --- |
| ASCII / UTF-8 | `true` | `true` | `,` |
| Windows-1252 | `true` | `false` | `,` |
| UTF-16LE + BOM | `true` | `false` | `,` |

Both non-UTF-8 cases are new regression tests in `tests/integration_tests.rs`; each asserts the dialect is still resolved correctly, since the sample is still transcoded before parsing.

## Deliberately out of scope

`detect_and_transcode`'s signature, `EncodingInfo`'s shape and `Metadata` are untouched. #44 reworks all three to surface the detected encoding name, and @guitcastro has offered a PR for it — this keeps that work conflict-free. `detect_and_transcode`'s second return value now has no reader; it is left in place with a comment pointing at the issue so it does not get tidied away before that PR lands.

## Notes

- Behavior change: anyone branching on `dialect.is_utf8` will now see `false` where they previously saw `true`. The old value carried no information, so nothing correct can have depended on it.
- The sample is now UTF-8-validated twice (once in `detect_encoding`, once inside `detect_and_transcode`). Negligible on a bounded sample with `simdutf8`, and #44 merges the two paths anyway.
- CHANGELOG entry is under `[Unreleased]`; the version decision for this plus #44 is still open.

Full suite green, clippy clean on the touched files.
